### PR TITLE
fix(minutas): creación sin folio/serial (BD lo asigna) + retry 23505

### DIFF
--- a/src/pages/minutas/nueva.tsx
+++ b/src/pages/minutas/nueva.tsx
@@ -4,26 +4,17 @@
  * ----------------------------------------------------------------------------
  * Cambios clave:
  * - Dejamos de delegar el submit a <MinuteForm/> para evitar que envíe
- *   `folio` o `folio_serial`. Ahora esta página llama a createMinute(...) de
- *   src/lib/minute.ts, que NO envía esos campos y maneja retry en 23505.
+ *   `folio` o `folio_serial`. Esta página llama a createMinute(...) de
+ *   src/lib/minutes.ts, que NO envía esos campos y maneja retry en 23505.
  * - Al guardar, redirige a /minutas/[id]#timer (aterriza en el cronómetro).
- * - UI minimal con Bootstrap; puedes reemplazar inputs por tus componentes
- *   si quieres mantener el look exacto.
- *
- * Accesibilidad:
- * - Botón Volver con aria-label.
- * - Mensajes claros y minimalistas.
- *
- * Buenas prácticas:
- * - router.replace para evitar volver a la página de creación con “Atrás”.
- * - Documentación exhaustiva en cada handler.
+ * - UI minimal con Bootstrap; puedes reemplazar inputs por tus componentes.
  */
 
 import { useState } from 'react'
 import { useRouter } from 'next/router'
 import Head from 'next/head'
 import { Form, Button, Card, Alert, Spinner, Row, Col } from 'react-bootstrap'
-import { createMinute } from '@/lib/minutes' // <- NUEVO: API controlada (sin folio/serial)
+import { createMinute } from '@/lib/minutes' // API controlada (sin folio/serial)
 import ui from '@/styles/NewMinute.module.css'
 import styles from '@/styles/Minutas.module.css'
 import { supabase } from '@/lib/supabaseClient'
@@ -52,16 +43,15 @@ export default function NuevaMinutaPage() {
     const pad = (n: number) => (n < 10 ? `0${n}` : `${n}`)
     return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}`
   })
-  const [start, setStart] = useState<string>('')
-  const [end, setEnd] = useState<string>('')
+  const [start, setStart] = useState<string>('')          // HH:mm (opcional)
+  const [end, setEnd] = useState<string>('')              // HH:mm (opcional)
   const [description, setDescription] = useState<string>('') // título/descr. principal
-  const [tarea, setTarea] = useState<string>('')            // opcional
-  const [novedades, setNovedades] = useState<string>('')    // opcional
+  const [tarea, setTarea] = useState<string>('')          // opcional
+  const [novedades, setNovedades] = useState<string>('')  // opcional
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   // Guard por sesión básica (si no hay sesión, rebotamos al login)
-  // Nota: si ya lo haces en _app o layout, puedes quitar este check.
   async function ensureSession() {
     const { data } = await supabase.auth.getUser()
     if (!data?.user) {


### PR DESCRIPTION
### Contexto
Al crear minutas en producción aparecía `duplicate key value violates unique constraint "minute_user_folio_unique"`.
El cliente estaba enviando `folio`/`folio_serial` y, en condiciones de carrera, chocaba con la asignación en BD.

### Qué cambia
- `src/lib/minutes.ts`:
  - **createMinute** ya **NO envía** `folio` ni `folio_serial` (los asigna el trigger de BD).
  - Inserción tolerante al esquema: detecta `user_id` vs `created_by`.
  - **Retry** (backoff 120ms) ante **23505** para resolver condiciones de carrera.
  - Manejo de columnas opcionales (`description`, `created_by_*`) de forma segura.
- `src/pages/minutas/nueva.tsx`:
  - Submit **controlado**: llama a `createMinute(...)` y redirige a `/minutas/[id]#timer`.
  - No pasa `folio`/`folio_serial` al backend.

### Alcance
- Solo afecta el **flujo de creación** de minutas.
- No toca vistas/admin ni permisos.

### Migraciones/Infra
- **Sin cambios de schema.** (Se asume que ya existen trigger/índice únicos en BD).

### Riesgo
Bajo. Cambios acotados a la creación.

### Validación / QA
1. Iniciar sesión como usuario normal.
2. Ir a **Minutas → Nueva**.
3. Crear una minuta con o sin horas. Debe:
   - Redirigir a `/minutas/[id]#timer`.
   - Mostrar folio asignado por BD.
   - **No** mostrar error de `duplicate key`.
4. Prueba de concurrencia:
   - Doble clic rápido en “Crear minuta” o dos pestañas en paralelo.
   - Debe crear **como mucho una** y no fallar con `23505` (si ocurre, se reintenta).
5. Abrir `/minutas/[id]` y verificar que el timer y campos renderizan correctamente.

### Monitoreo post-merge
- Revisar logs de Vercel/Supabase por nuev
