### PR TITLE
auth(gates): unifica gates de contraseña y protege páginas (SSR + CSR).

### DIFF
--- a/src/lib/supabaseServer.ts
+++ b/src/lib/supabaseServer.ts
@@ -1,0 +1,38 @@
+/**
+ * Cliente SSR de Supabase para Pages Router
+ * - Usa @supabase/ssr y cookies de Next (req/res).
+ * - Requisito: NEXT_PUBLIC_SUPABASE_URL y NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY (o ANON).
+ *
+ * Docs:
+ * - Crear cliente SSR: https://supabase.com/docs/guides/auth/server-side/creating-a-client
+ * - Next.js SSR (Pages Router): https://supabase.com/docs/guides/auth/server-side/nextjs
+ */
+import type { GetServerSidePropsContext } from 'next'
+import { createServerClient, type CookieOptions } from '@supabase/ssr'
+import { serialize } from 'cookie'
+
+export function createSupabaseServerClient(ctx: GetServerSidePropsContext) {
+  const { req, res } = ctx
+
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY! /* o ANON */,
+    {
+      cookies: {
+        get(name: string) {
+          return req.cookies[name]
+        },
+        set(name: string, value: string, options: CookieOptions) {
+          const setCookie = serialize(name, value, options)
+          const prev = res.getHeader('Set-Cookie')
+          res.setHeader('Set-Cookie', Array.isArray(prev) ? [...prev, setCookie] : [setCookie])
+        },
+        remove(name: string, options: CookieOptions) {
+          const setCookie = serialize(name, '', { ...options, maxAge: 0 })
+          const prev = res.getHeader('Set-Cookie')
+          res.setHeader('Set-Cookie', Array.isArray(prev) ? [...prev, setCookie] : [setCookie])
+        },
+      },
+    }
+  )
+}

--- a/src/lib/withAuthSSR.ts
+++ b/src/lib/withAuthSSR.ts
@@ -1,0 +1,72 @@
+// src/lib/withAuthSSR.ts
+import type {
+  GetServerSideProps,
+  GetServerSidePropsContext,
+  GetServerSidePropsResult,
+} from 'next'
+import { createSupabaseServerClient } from '@/lib/supabaseServer'
+
+// Opcionalmente puedes tipar user/supabase si ya importas tipos:
+// import type { SupabaseClient, User } from '@supabase/supabase-js'
+
+/**
+ * withAuthAndPwdGate
+ * -----------------------------------------------------------------------------
+ * Gate SSR: sesión obligatoria + clave temporal (profiles.must_change_password)
+ *
+ * - Sin sesión  -> /login?unauthorized=1&go=<ruta>
+ * - Con flag    -> /cambiar-password?go=<ruta>
+ * - Si OK       -> ejecuta getProps opcional y retorna props
+ *
+ * NOTA de tipos:
+ * Next pide que P extienda un objeto plano; por eso usamos:
+ *   P extends Record<string, any> = Record<string, any>
+ */
+export function withAuthAndPwdGate<
+  P extends Record<string, any> = Record<string, any>
+>(
+  getProps?: (
+    ctx: GetServerSidePropsContext,
+    supabase: any, // tipa como SupabaseClient si prefieres
+    user: any      // tipa como User si prefieres
+  ) => Promise<GetServerSidePropsResult<P>> | GetServerSidePropsResult<P>
+): GetServerSideProps<P> {
+  return async (ctx) => {
+    const supabase = createSupabaseServerClient(ctx)
+
+    // 1) Usuario validado por el servidor (revalida token con cookies)
+    const { data: userRes, error: userErr } = await supabase.auth.getUser()
+    const user = userRes?.user
+    if (userErr || !user) {
+      return {
+        redirect: {
+          destination: `/login?unauthorized=1&go=${encodeURIComponent(ctx.resolvedUrl)}`,
+          permanent: false,
+        },
+      }
+    }
+
+    // 2) Gate de "cambiar contraseña obligatoria"
+    const { data: prof } = await supabase
+      .from('profiles')
+      .select('must_change_password')
+      .eq('id', user.id)
+      .single()
+
+    if (prof?.must_change_password) {
+      return {
+        redirect: {
+          destination: `/cambiar-password?go=${encodeURIComponent(ctx.resolvedUrl)}`,
+          permanent: false,
+        },
+      }
+    }
+
+    // 3) Ejecuta getProps opcional de la página
+    if (getProps) {
+      return await getProps(ctx, supabase, user)
+    }
+
+    return { props: {} as P }
+  }
+}

--- a/src/pages/minutas/[id].tsx
+++ b/src/pages/minutas/[id].tsx
@@ -26,6 +26,7 @@ import LockTareaRealizada from '@/components/LockTareaRealizada'
 import { getMinuteByIdWithCreator, type MinuteWithCreator } from '@/lib/minutes'
 import { useRole } from '@/hooks/useRole'
 import { WORK_TYPE_LABEL } from '@/types/minute' // 👈 labels amigables de work_type
+import { withAuthAndPwdGate } from '@/lib/withAuthSSR'
 
 type IntervalRow = {
   id: string
@@ -547,3 +548,4 @@ export default function MinuteDetailPage() {
     </SessionGate>
   )
 }
+export const getServerSideProps = withAuthAndPwdGate()

--- a/src/pages/minutas/estadisticas.tsx
+++ b/src/pages/minutas/estadisticas.tsx
@@ -26,6 +26,7 @@ import {
 import { FiArrowLeft, FiInfo } from 'react-icons/fi'
 import { supabase } from '@/lib/supabaseClient'
 import RequireRole from '@/components/RequireRole' // 🔒 GATING por rol
+import { withAuthAndPwdGate } from '@/lib/withAuthSSR'
 
 // ---------- Recharts: dynamic con { default: ... } + ssr:false ----------
 const ResponsiveContainer = dynamic(
@@ -871,3 +872,18 @@ export default function AdminEstadisticasPage() {
     </RequireRole>
   )
 }
+export const getServerSideProps = withAuthAndPwdGate(async (ctx, supabase, user) => {
+  const { data: prof } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  if (prof?.role !== 'admin' && prof?.role !== 'super_admin') {
+    return {
+      redirect: { destination: '/mis-minutas?unauthorized=1', permanent: false },
+    }
+  }
+
+  return { props: {} }
+})

--- a/src/pages/minutas/index.tsx
+++ b/src/pages/minutas/index.tsx
@@ -22,6 +22,7 @@ import styles from '@/styles/Minutas.module.css'
 import { useFirstLoginGate } from '@/hooks/useFirstLoginGate'
 import AdminResetPassword from '@/components/AdminResetPassword'
 import RequireRole from '@/components/RequireRole'
+import { withAuthAndPwdGate } from '@/lib/withAuthSSR'
 
 type Filters = { desde?: string; hasta?: string; user?: string }
 type UserOption = { value: string; label: string }
@@ -222,3 +223,18 @@ function AdminMinutasView() {
     </Container>
   )
 }
+export const getServerSideProps = withAuthAndPwdGate(async (ctx, supabase, user) => {
+  const { data: prof } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  if (prof?.role !== 'admin' && prof?.role !== 'super_admin') {
+    return {
+      redirect: { destination: '/mis-minutas?unauthorized=1', permanent: false },
+    }
+  }
+
+  return { props: {} }
+})

--- a/src/pages/mis-minutas.tsx
+++ b/src/pages/mis-minutas.tsx
@@ -36,6 +36,11 @@ import styles from '@/styles/Minutas.module.css'
 import { BsPlusLg } from 'react-icons/bs'
 import { useRole } from '@/hooks/useRole'
 import { deleteMinute as apiDeleteMinute } from '@/lib/minutes'
+import { withAuthAndPwdGate } from '@/lib/withAuthSSR'
+// src/pages/mis-minutas.tsx
+
+
+
 
 /** Lista blanca de correos que pueden ver el botón Eliminar (tester). */
 const TEST_DELETE_EMAILS: string[] = (process.env.NEXT_PUBLIC_TEST_DELETE_EMAILS || '')
@@ -135,6 +140,7 @@ export default function MisMinutasPage() {
     </SessionGate>
   )
 }
+export const getServerSideProps = withAuthAndPwdGate()
 
 /* ============================= CONTENIDO worker ============================= */
 
@@ -348,5 +354,7 @@ function DeleteModal({
         </Button>
       </Modal.Footer>
     </Modal>
+    
   )
+  
 }


### PR DESCRIPTION
- withAuthSSR: HOC con redirect 302 cuando no hay sesión / must_change_password.
- hooks: usePasswordChangeGate y useFirstLoginGate desacoplados.
- páginas protegidas: mis-minutas, minutas, minutas/[id], minutas/estadisticas.
- flujo de crear nueva minuta (sin horas) → detalle#timer.
- sin cambios en DB ni triggers/policies.